### PR TITLE
Fixes missing GraphQL registration

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -16,6 +16,7 @@ use craft\digitalproducts\elements\Product;
 use craft\digitalproducts\fieldlayoutelements\ProductTitleField;
 use craft\digitalproducts\fields\Products;
 use craft\digitalproducts\gql\interfaces\elements\Product as GqlProductInterface;
+use craft\digitalproducts\gql\queries\Product as GqlProductQueries;
 use craft\digitalproducts\helpers\ProjectConfigData;
 use craft\digitalproducts\models\Settings;
 use craft\digitalproducts\plugin\Routes;
@@ -27,6 +28,7 @@ use craft\events\DefineFieldLayoutFieldsEvent;
 use craft\events\RebuildConfigEvent;
 use craft\events\RegisterComponentTypesEvent;
 use craft\events\RegisterGqlSchemaComponentsEvent;
+use craft\events\RegisterGqlQueriesEvent;
 use craft\events\RegisterGqlTypesEvent;
 use craft\events\RegisterUserPermissionsEvent;
 use craft\helpers\UrlHelper;
@@ -95,6 +97,7 @@ class Plugin extends BasePlugin
         $this->_registerPermissions();
         $this->_registerElementTypes();
         $this->_registerGqlInterfaces();
+        $this->_registerGqlQueries();
         $this->_registerGqlComponents();
         $this->_defineFieldLayoutElements();
         $this->_registerGarbageCollection();
@@ -371,6 +374,19 @@ class Plugin extends BasePlugin
                 $event->types = $types;
             }
         );
+    }
+
+    /**
+     * Register the Gql queries
+     */
+    private function _registerGqlQueries(): void
+    {
+        Event::on(Gql::class, Gql::EVENT_REGISTER_GQL_QUERIES, static function(RegisterGqlQueriesEvent $event) {
+            $event->queries = array_merge(
+                $event->queries,
+                GqlProductQueries::getQueries(),
+            );
+        });
     }
 
     /**


### PR DESCRIPTION
### Description

This PR restores GraphQL support for Digital Products.

If it’s possible to do a 4.x release as well, this is a 4.x branch that should be ready to merge in:
https://github.com/kennethormandy/craft-digitalproducts/tree/bugfix/graphql-support-4.x

It only includes this commit + d9597c7eff201df59fe5b167a66d705103904095.

### Related issues

#96
