### PR TITLE
Adds content migration, fixing upgrading from Craft 4

### DIFF
--- a/src/migrations/m240620_150738_content_refactor_elements.php
+++ b/src/migrations/m240620_150738_content_refactor_elements.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace craft\digitalproducts\migrations;
+
+use craft\db\Query;
+use craft\digitalproducts\db\Table;
+use craft\digitalproducts\Plugin;
+use craft\migrations\BaseContentRefactorMigration;
+
+/**
+ * m240620_150738_content_refactor_elements migration.
+ */
+class m240620_150738_content_refactor_elements extends BaseContentRefactorMigration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        // Migrate digital products by product type
+        foreach (Plugin::getInstance()->getProductTypes()->getAllProductTypes() as $productType) {
+            $this->updateElements(
+                (new Query())->from(Table::PRODUCTS)->where(['typeId' => $productType->id]),
+                $productType->getProductFieldLayout()
+            );
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m240620_150738_content_refactor_elements cannot be reverted.\n";
+        return false;
+    }
+}


### PR DESCRIPTION
### Description

Currently, best I could tell, there is a migration from Craft 4 → 5 missing for digital products. At a minimum, the products won’t have titles after the upgrade.

Using a fresh install of the latest 4.x versions of Craft, Commerce, and Digital Products:

![Screenshot 2024-06-20 at 06-32-08 My Example Product - Digital Products](https://github.com/craftcms/digital-products/assets/1581276/028d159e-79af-4ada-803a-817886307cf5)

…you end up with this on Craft 5:

![Screenshot 2024-06-20 at 06-36-20 Products - Digital Products - Digital Products](https://github.com/craftcms/digital-products/assets/1581276/161c0607-22a2-4800-8d4d-5f92ee8995b6)

I added a migration based on https://github.com/craftcms/commerce/blob/5e8d4b4b55b23a31d8a883efd8d6a23e21991572/src/migrations/m240119_073924_content_refactor_elements.php. It seems to have resolved the issue I was seeing, but I’m not sure if that’s actually all that’s needed.

Thanks!